### PR TITLE
fix: asynchronous bug during multiple queries

### DIFF
--- a/final/pages/edit.js
+++ b/final/pages/edit.js
@@ -10,8 +10,15 @@ const EditNote = props => {
   // store the id found in the url as a variable
   const id = props.match.params.id;
   // define our note query
-  const { loading, error, data } = useQuery(GET_NOTE, { variables: { id } });
-  const { data: userdata } = useQuery(GET_ME);
+  const {
+    loading: noteLoading,
+    error: noteError,
+    data: noteData } = useQuery(GET_NOTE, { variables: { id } });
+  // fetch the current user's data
+  const {
+    loading: userLoading,
+    error: userError,
+    data: userData } = useQuery(GET_ME);
   // define our mutation
   const [editNote] = useMutation(EDIT_NOTE, {
     variables: {
@@ -23,16 +30,16 @@ const EditNote = props => {
   });
 
   // if the data is loading, display a loading message
-  if (loading) return 'Loading...';
+  if (noteLoading || userLoading) return 'Loading...';
   // if there is an error fetching the data, display an error message
-  if (error) return <p>Error!</p>;
+  if (noteError || userError) return <p>Error!</p>;
   // if the current user and the author of the note do not match
-  if (userdata.me.id !== data.note.author.id) {
+  if (userData.me.id !== noteData.note.author.id) {
     return <p>You do not have access to edit this note</p>;
   }
 
   // pass the data and mutation to the form component
-  return <NoteForm content={data.note.content} action={editNote} />;
+  return <NoteForm content={noteData.note.content} action={editNote}/>;
 };
 
 export default EditNote;


### PR DESCRIPTION
Fixed an asynchronous bug. If GET_NOTE query finishes before GET_ME query userdata.me.id is still undefined but executed. Fixed by renaming loading, error and data variables in each query and including it in Loading and Error if's.